### PR TITLE
chore: install job 변경

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -17,6 +17,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - uses: actions/checkout@v2
       - name: Install
-        run: npm ci
+        run: npm install
       - name: Run test
         run: npm test


### PR DESCRIPTION
`npm ci` 는 **package-lock.json** 파일이 있어야 한다.